### PR TITLE
Add data types to InfluxDB measurements

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,3 +427,20 @@ Gradle needs Java runtime, and the version of Gradle used in this project uses J
 ```
 export JAVA_HOME=/usr/local/opt/openjdk@17
 ```
+
+### Debug Output
+
+During development it can be useful to get output from tests to the console.
+
+```groovy
+@Test
+void foo_SomeBar_GetSomeBaz() {
+    println(someObjectToDebug)
+}
+```
+
+Enable log info level to display `println` statements in the test output.
+
+```sh
+./gradlew test --info
+```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Jenkins Shared Library for Unity
 
 [![Test Suite](https://github.com/artstorm/jenkins-shared-library-unity/actions/workflows/tests.yml/badge.svg)](https://github.com/artstorm/jenkins-shared-library-unity/actions)
+[![Mastodon: @johansteen](https://img.shields.io/badge/mastodon-@johansteen-blue.svg?logo=mastodon&logoColor=ffffff&labelColor=383f47)](https://mastodon.gamedev.place/@johansteen)
 [![Twitter: @artstorm](https://img.shields.io/badge/twitter-@artstorm-blue.svg?logo=twitter&logoColor=ffffff&labelColor=383f47)](https://twitter.com/artstorm)
 [![Discord: Bitbebop](https://img.shields.io/badge/chat-discord-blue?logo=discord&logoColor=ffffff&labelColor=383f47)](https://discord.gg/WJn7w5WaU9)
 

--- a/README.md
+++ b/README.md
@@ -324,7 +324,13 @@ success {
 
 #### InfluxFB Add Measurement
 
-Add a measurement for writing to InfluxDB.
+Add a measurement for writing to InfluxDB. The data type for each field in teh measurement is set with a string.
+
+| value | Data type |
+| ----- | --------- |
+| `"f"` | float     |
+| `"i"` | integer   |
+| `"s"` | string    |
 
 ```groovy
 influxdb.addMeasurement("build",
@@ -333,12 +339,13 @@ influxdb.addMeasurement("build",
         build_type: buildType
     ],
     [
-        size: size,
-        duration_unity: timers.getDuration("Unity.${platform}"),
-        duration_xcode: timers.getDuration("Xcode.${platform}"),
-        jenkins_build_number: currentBuild.number,
-        unity_build_number: unityBuildNumber(),
-        commit_sha: env.GIT_COMMIT_SHA_SHORT
+        code_coverage: ["f", coverage.lineCoverage],
+        size: ["i", size],
+        duration_unity: ["i", timers.getDuration("Unity.${platform}")],
+        duration_xcode: ["i", timers.getDuration("Xcode.${platform}")],
+        jenkins_build_number: ["i", currentBuild.number],
+        unity_build_number: ["i", unityBuildNumber()],
+        commit_sha: ["s", env.GIT_COMMIT_SHA_SHORT]
     ]
 )
 ```

--- a/src/com/bitbebop/InfluxDB.groovy
+++ b/src/com/bitbebop/InfluxDB.groovy
@@ -1,0 +1,52 @@
+package com.bitbebop
+
+/**
+ * Collects measurements for writing to InfluxDB.
+ *
+ * The provided measurement data is transformed to InfluxDB line protocol.
+ * https://docs.influxdata.com/influxdb/v2.6/reference/syntax/line-protocol/
+ */
+class InfluxDB {
+    private def measurements = []
+
+    /**
+     * Add a measurement for writing to InfluxDB.
+     *
+     * @param String measurement The measurement to write data to.
+     * @param Map    tags        The measurement tags.
+     * @param Map    fields      The measurement fields, each field is an array
+     *                           with type and value.
+     */
+    def addMeasurement(String measurement, def tags, def fields) {
+
+        def tagsString = tags.collect { /$it.key=$it.value/ } join ","
+        if (tagsString.length() > 0) {
+            tagsString = ",${tagsString}"
+        }
+
+        def fieldsString = fields.collect {
+            switch(it.value[0]) {
+                case "f":
+                /$it.key=${it.value[1]}/
+                break;
+                case "i":
+                /$it.key=${it.value[1]}i/
+                break;
+                case "s":
+                /$it.key="${it.value[1]}"/
+                break;
+            }
+        } join ","
+
+        def line = "${measurement}${tagsString} ${fieldsString}"
+        measurements.add(line)
+    }
+
+    /**
+     * Get the array of line protocol formatted strings, that can be written to
+     * InfluxDB.
+     */
+    def getMeasurements() {
+        return measurements
+    }
+}

--- a/src/com/bitbebop/InfluxDB.groovy
+++ b/src/com/bitbebop/InfluxDB.groovy
@@ -25,16 +25,15 @@ class InfluxDB {
         }
 
         def fieldsString = fields.collect {
-            switch(it.value[0]) {
-                case "f":
+            // Note for future similar functionality:
+            // I tried using a switch statement instead of else if. While that
+            // works in the test ebv, the Jenkins instance couldn't handle it.
+            if (it.value[0] == "f") {
                 /$it.key=${it.value[1]}/
-                break;
-                case "i":
+            } else if (it.value[0] == "i") {
                 /$it.key=${it.value[1]}i/
-                break;
-                case "s":
+            } else if (it.value[0] == "s") {
                 /$it.key="${it.value[1]}"/
-                break;
             }
         } join ","
 

--- a/test/com/bitbebop/InfluxDBTests.groovy
+++ b/test/com/bitbebop/InfluxDBTests.groovy
@@ -1,0 +1,78 @@
+import org.junit.*
+import com.lesfurets.jenkins.unit.BasePipelineTest
+import static groovy.test.GroovyAssert.*
+
+import com.bitbebop.InfluxDB
+
+class InfluxDBTests extends BasePipelineTest {
+    @Test
+    void addMeasurement_NoTag_SkipsTagSegment() {
+        def influxDB = new InfluxDB();
+            influxDB.addMeasurement("foo", [:], [a_float: ["f", 123.45]]
+        )
+
+        def measurements = influxDB.getMeasurements()
+        assertEquals "No Tag:", /foo a_float=123.45/, measurements[0].toString()
+    }
+
+    @Test
+    void addMeasurement_WithTag_AddsTagSegment() {
+        def influxDB = new InfluxDB();
+            influxDB.addMeasurement("foo", [some_tag:"tag_value"], [a_float: ["f", 123.45]]
+        )
+
+        def measurements = influxDB.getMeasurements()
+        assertEquals "With Tag:", /foo,some_tag=tag_value a_float=123.45/, measurements[0].toString()
+    }
+
+    @Test
+    void addMeasurement_WithMultipleTags_AddsJoinedTagSegment() {
+        def influxDB = new InfluxDB();
+            influxDB.addMeasurement("foo", [some_tag:"tag_value", some_other_tag:"another_tag_value"], [a_float: ["f", 123.45]]
+        )
+
+        def measurements = influxDB.getMeasurements()
+        assertEquals "With Multiple Tags:", /foo,some_tag=tag_value,some_other_tag=another_tag_value a_float=123.45/, measurements[0].toString()
+    }
+
+    @Test
+    void addMeasurement_FloatDataType_RemainsAsIs() {
+        def influxDB = new InfluxDB();
+            influxDB.addMeasurement("foo", [:], [a_float: ["f", 123.45]]
+        )
+
+        def measurements = influxDB.getMeasurements()
+        assertEquals "Float Datatype:", /foo a_float=123.45/, measurements[0].toString()
+    }
+
+    @Test
+    void addMeasurement_IntDataType_EndsWithi() {
+        def influxDB = new InfluxDB();
+            influxDB.addMeasurement("foo", [:], [an_int: ["i", 123]]
+        )
+
+        def measurements = influxDB.getMeasurements()
+        assertEquals "Int Datatype:", /foo an_int=123i/, measurements[0].toString()
+    }
+
+    @Test
+    void addMeasurement_StringDataType_HasQuotes() {
+        def influxDB = new InfluxDB();
+            influxDB.addMeasurement("foo", [:], [a_str: ["s", "some string"]]
+        )
+
+        def measurements = influxDB.getMeasurements()
+        assertEquals "String Datatype:", /foo a_str="some string"/, measurements[0].toString()
+    }
+
+    @Test
+    void addMeasurement_WithMultipleFields_FieldsAreJoined() {
+        def influxDB = new InfluxDB();
+            influxDB.addMeasurement("foo", [:], [a_str: ["s", "some string"], an_int: ["i", 123]]
+        )
+
+        def measurements = influxDB.getMeasurements()
+        assertEquals "String Datatype:", /foo a_str="some string",an_int=123i/, measurements[0].toString()
+    }
+
+}

--- a/vars/influxdb.groovy
+++ b/vars/influxdb.groovy
@@ -5,9 +5,9 @@
  * Measurements are collected with the addMeasurement method. Calling the write
  * method will write all collected measurements in the same call to InfluxDB.
  */
+import com.bitbebop.InfluxDB
 
-// Array that holds the measurements to write to InfluxDB.
-@groovy.transform.Field private def measurements = []
+@groovy.transform.Field private def influxDB = new InfluxDB()
 
 /**
  * Add a measurement for writing to InfluxDB.
@@ -16,32 +16,31 @@
  * https://docs.influxdata.com/influxdb/v2.6/reference/syntax/line-protocol/
  *
  * @param String measurement The measurement to write data to.
- * @param Map tags The measurement tags.
- * @param Maps fields The measurement fields.
+ * @param Map    tags        The measurement tags.
+ * @param Map    fields      The measurement fields, each field is an array
+ *                           with type and value.
  */
 def addMeasurement(String measurement, def tags, def fields) {
+    influxDB.addMeasurement(measurement, tags, fields)
+}
 
-    def tagsString = tags.collect { /$it.key=$it.value/ } join ","
-    if (tagsString.length() > 0) {
-        tagsString = ",${tagsString}"
-    }
-
-    def fieldsString = fields.collect { it.value instanceof String ? /$it.key="$it.value"/ : /$it.key=$it.value/ } join ","
-
-    def line = "${measurement}${tagsString} ${fieldsString}"
-    measurements.add(line)
+/**
+ * Get the array of line protocol formatted strings.
+ */
+def getMeasurements() {
+    return influxDB.getMeasurements()
 }
 
 /**
  * Write all added measurements to InfluxDB.
  *
- * @param String host The host address to InfluxDB. Include http/https. No trailing slash.
- * @param String org The InfluxDB organization.
+ * @param String host   The host address to InfluxDB. Include http/https. No trailing slash.
+ * @param String org    The InfluxDB organization.
  * @param String bucket The bucket to write to.
- * @param String token The InfluxDB API token to use for authentication.
+ * @param String token  The InfluxDB API token to use for authentication.
  */
 def write(String host, String org, String bucket, String token) {
-    if (this.measurements.size() == 0) {
+    if (getMeasurements().size() == 0) {
         return
     }
 
@@ -51,5 +50,5 @@ def write(String host, String org, String bucket, String token) {
     '--header "Content-Type: text/plain; charset=utf-8" ' +
     '--header "Accept: application/json" ' +
     '--fail-with-body ' +
-    "--data-binary '${this.measurements.join('\n')}'"
+    "--data-binary '${getMeasurements().join('\n')}'"
 }


### PR DESCRIPTION
The line protocol has indicators for the desired datatype a field value uses. This PR adds support for including that.